### PR TITLE
Automatically assign code owners review 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @imskr, @Ishaan28malik and @atcodedog32 will be requested for
+# review when someone opens a pull request.
+*   @imskr @Ishaan28malik @atcodedog32


### PR DESCRIPTION
<!-- 
The title of the pull request should be of this format <Title_of_Issue>_resolved 
The PR should be raised only after making all changes relevant to the issue (all commits)
-->

## Issue that this pull request solves

 Closes #60

## Proposed changes

Brief description of what is fixed or changed
- Files changed
  * Added `.github/CODEOWNERS`
- Dependencies if any (on other issues/PRs): None
- Basic tests done to validate: None. Reference used from [help.github.com](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)
- Conflicts if any (describe the reason for conflict): None

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

No change in user interface

## Other information

* [`CODEOWNERS`](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
* P.S.: This feature is supposed to be working after this PR is merged.

<!-- <tag mentor/project admin> to review and merge -->
@imskr 